### PR TITLE
Add viewport preset command, make default viewport size explicit

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,7 @@
     "integrationFolder": "tests/cypress/integration",
     "pluginsFile": "tests/cypress/plugins/index.js",
     "supportFile": "tests/cypress/support/index.js",
-    "videosFolder": "tests/cypress/videos"
+    "videosFolder": "tests/cypress/videos",
+    "viewportHeight": 660,
+    "viewportWidth": 1000
 }

--- a/cypress.json
+++ b/cypress.json
@@ -4,7 +4,5 @@
     "integrationFolder": "tests/cypress/integration",
     "pluginsFile": "tests/cypress/plugins/index.js",
     "supportFile": "tests/cypress/support/index.js",
-    "videosFolder": "tests/cypress/videos",
-    "viewportHeight": 660,
-    "viewportWidth": 1000
+    "videosFolder": "tests/cypress/videos"
 }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -35,3 +35,28 @@ Cypress.Commands.add('login', (user, password) => {
 
   cy.get('form#login').submit()
 })
+
+Cypress.Commands.add('viewportPreset', (size = '') => {
+  switch (size) {
+    case 'samsung-s10-plus':
+      cy.viewport(412, 869)
+      break
+    case 'iphone-se': 
+      cy.viewport(375, 667)
+      break
+    case 'ipad-pro':
+      cy.viewport(1366, 1024)
+      break
+    case 'ms-surface':
+      cy.viewport(1280, 720)
+      break
+    case 'full-hd':
+      cy.viewport(1920, 1080)
+      break
+    case 'imac':
+      cy.viewport(2560, 1440)
+      break
+    default:
+      cy.viewport(Cypress.env('viewportWidth'), Cypress.env('viewportHeight'))
+  }
+})


### PR DESCRIPTION
Changes: 
* Added a command for setting the viewport according to popular devices, using a lowercase hyphenated string, e.g. `iphone-se`
* Added the default viewport size to `cypress.json` 