### PR TITLE
Add GitLab CI config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,32 @@
+stages:
+  - test
+
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - node_modules/
+    - .npm/
+
+.test:
+  image: cypress/browsers:node14.17.0-chrome91-ff89
+  stage: test
+  before_script:
+    - npm ci
+  artifacts:
+    when: always
+    paths:
+      - cypress/videos/**/*.mp4
+      - cypress/screenshots/**/*.png
+    expire_in: 1 day
+
+test_chrome:
+  extends: .test
+  script:
+    - npm run start:ci &
+    - npx cypress run
+
+test_firefox:
+  extends: .test
+  script:
+    - npm run start:ci &
+    - npx cypress run --browser firefox

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,8 @@ cache:
   artifacts:
     when: always
     paths:
-      - cypress/videos/**/*.mp4
-      - cypress/screenshots/**/*.png
+      - tests/cypress/videos/**/*.mp4
+      - tests/cypress/screenshots/**/*.png
     expire_in: 1 day
 
 test_chrome:


### PR DESCRIPTION
Add a `gitlab-ci.yml` file to enable GitLab CI runs on the GitLab mirror of this repo:
https://gitlab.com/james.sheasby.thomas/cypress-starter-kit

You can see an example test run here:
https://gitlab.com/james.sheasby.thomas/cypress-starter-kit/-/pipelines/382679150