### PR TITLE
Fix gitlab ci script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,11 +22,8 @@ cache:
 test_chrome:
   extends: .test
   script:
-    - npm run start:ci &
     - npx cypress run
 
 test_firefox:
   extends: .test
-  script:
-    - npm run start:ci &
     - npx cypress run --browser firefox

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,4 +26,5 @@ test_chrome:
 
 test_firefox:
   extends: .test
+  script:
     - npx cypress run --browser firefox


### PR DESCRIPTION
Remove `- npm run start:ci &` step from GitLab CI jobs, as they are not needed for this proof of concept pipeline.